### PR TITLE
Added a boolean in CuraStage.py to say whether stages should show the…

### DIFF
--- a/cura/Stages/CuraStage.py
+++ b/cura/Stages/CuraStage.py
@@ -15,6 +15,8 @@ from UM.Stage import Stage
 class CuraStage(Stage):
     def __init__(self, parent = None) -> None:
         super().__init__(parent)
+        # True if the toolbar should be visible when this stage is active
+        self._toolbarEnabled = False
 
     @pyqtProperty(str, constant = True)
     def stageId(self) -> str:
@@ -27,6 +29,10 @@ class CuraStage(Stage):
     @pyqtProperty(QUrl, constant = True)
     def stageMenuComponent(self) -> QUrl:
         return self.getDisplayComponent("menu")
+
+    @pyqtProperty(bool, constant = True)
+    def toolbarEnabled(self) -> bool:
+        return self._toolbarEnabled
 
 
 __all__ = ["CuraStage"]

--- a/plugins/PrepareStage/PrepareStage.py
+++ b/plugins/PrepareStage/PrepareStage.py
@@ -13,6 +13,7 @@ class PrepareStage(CuraStage):
     def __init__(self, parent = None):
         super().__init__(parent)
         Application.getInstance().engineCreatedSignal.connect(self._engineCreated)
+        self._toolbarEnabled = True
 
     def _engineCreated(self):
         menu_component_path = os.path.join(PluginRegistry.getInstance().getPluginPath("PrepareStage"), "PrepareMenu.qml")

--- a/plugins/PreviewStage/PreviewStage.py
+++ b/plugins/PreviewStage/PreviewStage.py
@@ -25,6 +25,7 @@ class PreviewStage(CuraStage):
         self._application = application
         self._application.engineCreatedSignal.connect(self._engineCreated)
         self._previously_active_view = None  # type: Optional[View]
+        self._toolbarEnabled = True
 
     def onStageSelected(self) -> None:
         """When selecting the stage, remember which was the previous view so that

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -318,7 +318,7 @@ UM.MainWindow
                     verticalCenter: tallerThanParent ? undefined : parent.verticalCenter
                     left: parent.left
                 }
-                visible: CuraApplication.platformActivity && !PrintInformation.preSliced
+                visible: CuraApplication.platformActivity && !PrintInformation.preSliced && UM.Controller.activeStage.toolbarEnabled
             }
 
             // A hint for the loaded content view. Overlay items / controls can safely be placed in this area


### PR DESCRIPTION
… toolbar.

By default they won't.

CURA-9401

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
